### PR TITLE
feat: force flag

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -14,6 +14,7 @@ pub struct Args {
     pub branch: Option<String>,
     /// Prints the path to the user configuration file.
     #[clap(
+        conflicts_with("force"),
         conflicts_with("git"),
         conflicts_with("interactive"),
         conflicts_with("parameters"),
@@ -27,6 +28,9 @@ pub struct Args {
     /// The items are space delimited.
     #[clap(long, short)]
     pub features: Option<Vec<String>>,
+    /// If true overwrites the target folder even if it is non-empty.
+    #[clap(conflicts_with("config-path"), long)]
+    pub force: bool,
     /// The git repository to use as a template.
     ///
     /// A branch can optionally be set by appending an `@<branch name>`.

--- a/src/steps/clone.rs
+++ b/src/steps/clone.rs
@@ -6,7 +6,7 @@ use crate::{
     git::{clone_into_folder, parse_to_git_url},
 };
 use anyhow::Result;
-use std::{env, path::PathBuf, process::exit};
+use std::{env, fs, path::PathBuf, process::exit};
 
 // Changing to `or_else` does mean that the function owns the reference and thus
 // fails on compilation.
@@ -33,11 +33,16 @@ pub fn run(args: &Args, user_config: &UserConfig) -> Result<PathBuf> {
         let repository_dir_path = env::current_dir()?.join(&args.name.as_ref().unwrap());
         // Check if the folder already exists.
         if repository_dir_path.exists() {
-            eprintln!(
-                "A folder named {:?} already exists!",
-                &args.name.as_ref().unwrap()
-            );
-            exit(1);
+            // If forced, delete the old folder and continue.
+            if args.force {
+                fs::remove_dir_all(&repository_dir_path)?;
+            } else {
+                eprintln!(
+                    "A folder named {:?} already exists! Use `--force` or another project name.",
+                    &args.name.as_ref().unwrap()
+                );
+                exit(1);
+            }
         }
         clone_into_folder(&repository_url, &args.branch.as_ref(), &repository_dir_path)?;
 


### PR DESCRIPTION
If the folder that the template repository should be cloned into already
exists, the `--force` flag can now be used to delete the old folder and
continue with the program execution as normal instead of exiting.

Closes #23