### PR TITLE
fix!: config flag conflicts not set correctly

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -14,9 +14,11 @@ pub struct Args {
     pub branch: Option<String>,
     /// Prints the path to the user configuration file.
     #[clap(
+        conflicts_with("features"),
         conflicts_with("force"),
         conflicts_with("git"),
         conflicts_with("interactive"),
+        conflicts_with("name"),
         conflicts_with("parameters"),
         conflicts_with("profile"),
         long,


### PR DESCRIPTION
The commit does now correctly restrict the usage of `-c` to only be ever
allowed on its own. Prior to this commit there where some flags (`-nf`)
that could be invoked together with `-c` and not throw an error.

BREAKING CHANGE: Invocations from external sources like scripts now fail
if they passed `-c` together with either `-n` or `-f`.

Fixes #26