### PR TITLE
fix!: template features not correctly resolvable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,7 @@ dependencies = [
  "console 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "directories-next 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.13.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "inventory 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ chrono = { version = "0.4.13", features = ["serde"] }
 console = "0.11.3"
 directories-next = "1.0.1"
 git2 = "0.13.8"
+heck = "0.3.1"
 indicatif = "0.15.0"
 inventory = "0.1.7"
 log = "0.4.11"

--- a/src/steps/apply.rs
+++ b/src/steps/apply.rs
@@ -26,11 +26,7 @@ pub fn run(
 
         // Only check if the user actually specified some features that he wants.
         let files_to_delete: Vec<&str> = if let Some(features) = &args.features {
-            let slice_of_features = &template_config
-                .features
-                .iter()
-                .map(|feat| feat)
-                .collect::<Vec<_>>();
+            let slice_of_features = &template_config.features.iter().collect::<Vec<_>>();
 
             let mut resolved_features = Vec::new();
             features

--- a/src/steps/populate.rs
+++ b/src/steps/populate.rs
@@ -4,6 +4,7 @@ use crate::{
     providers::{ConfigurableVariableProvider, VariableProvider},
 };
 use anyhow::Result;
+use heck::SnakeCase;
 use std::{collections::HashMap, fs, path::Path};
 use tera::{Context, Tera};
 use walkdir::WalkDir;
@@ -16,7 +17,7 @@ pub fn run(args: &Args, user_config: &UserConfig, repo_path: impl AsRef<Path>) -
     if let Some(enabled_features) = &args.features {
         let mut bool_map = HashMap::with_capacity(enabled_features.len());
         for enabled_feature in enabled_features {
-            bool_map.insert(enabled_feature, true);
+            bool_map.insert(enabled_feature.to_snake_case(), true);
         }
         ctx.insert("features", &bool_map);
     }


### PR DESCRIPTION
Feature names, originally, should have been addressable by using their
name in snake_case, e.g. `{% if features.cli_simple %}`. However,
features have been added by just using their name defined inside the
features section of the template configuration file. This behavior has
been changed to convert the feature name to snake_case before inserting
it into the `Context`.

BREAKING CHANGE: features are now addressable using their snake_case
name conversion.

Fixes #34