### PR TITLE
fix: `-b` usage together with `-p`

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -10,7 +10,7 @@ pub struct Args {
     /// The git branch to checkout.
     ///
     /// If not specified the default remote branch is used.
-    #[clap(conflicts_with("config-path"), conflicts_with("profile"), long, short)]
+    #[clap(conflicts_with("config-path"), long, short)]
     pub branch: Option<String>,
     /// Prints the path to the user configuration file.
     #[clap(


### PR DESCRIPTION
This commit now allows to use the `-b,--branch` flag together with the
`-p,--profile` argument.

Fixes #33